### PR TITLE
A couple bug fixes

### DIFF
--- a/src/MPIUtil.jl
+++ b/src/MPIUtil.jl
@@ -3,9 +3,16 @@ import MPI
 
 #TODO document
 
+# The RSend constand isn't defined on windows
+const MPI_RSEND = if Sys.iswindows()
+                      (:MPI_RSEND, MPI.libmpi)
+                  else
+                      MPI.MPI_RSEND
+                  end
+
 function MPI_Rsend(buf::MPI.MPIBuffertype{T}, count::Integer,
                 dest::Integer, tag::Integer, comm::MPI.Comm) where T
-    ccall(MPI.MPI_RSEND, Nothing,
+    ccall(MPI_RSEND, Nothing,
         (Ptr{T}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint},
            Ref{Cint}),
         buf, count, MPI.mpitype(T), dest, tag, comm.val, 0)

--- a/src/MultiVector.jl
+++ b/src/MultiVector.jl
@@ -235,7 +235,7 @@ Base.eltype(::MultiVector{Data}) where Data = Data
 Base.size(A::MultiVector) = (Int(globalLength(A)), Int(numVectors(A)))
 
 #TODO this might break for funky maps, however indices needs to return a unit range
-Base.axes(A::MultiVector) = (minMyGID(A.map):maxMyGID(A.map), 1:numVectors(A))
+Base.axes(A::MultiVector) = (minMyGID(getMap(A)):maxMyGID(getMap(A)), 1:numVectors(A))
 
 function Base.getindex(A::MultiVector, row::Integer, col::Integer)
     @boundscheck begin
@@ -275,7 +275,7 @@ end
 
 function Base.setindex!(A::MultiVector, v, row::Integer, col::Integer)
     @boundscheck begin
-        if !(1<=col<=A.numVectors)
+        if !(1<=col<=numVectors(A))
             throw(BoundsError(A, (row, col)))
         end
     end
@@ -293,7 +293,7 @@ function Base.setindex!(A::MultiVector, v, row::Integer, col::Integer)
 end
 
 function Base.setindex!(A::MultiVector, v, i::Integer)
-    if A.numVectors != 0
+    if numVectors(A) != 0
         throw(ArgumentError("Can only use single index if there is just 1 vector"))
     end
 


### PR DESCRIPTION
This fixes some issues with
1) some `MultiVector` methods assuming that a `DenseMultiVector` was passed
2) MPI_RSend not being defined on windows

I figured I should add this via Pull Request, since I've graduated and am not working on this anymore.